### PR TITLE
Fix NRE when attempting to stop zoom coroutine after reloading the world

### DIFF
--- a/VRZoom/BindInputVr.cs
+++ b/VRZoom/BindInputVr.cs
@@ -6,7 +6,6 @@ namespace VRZoom;
 static class BindInputVr
 {
 	private static bool zoomRequested = false;
-	private static Zoomer? zoomer;
 
 	static void Postfix(LocomotionInputVr __instance)
 	{
@@ -15,7 +14,9 @@ static class BindInputVr
 		if (wasZoomRequested != zoomRequested)
 		{
 			Main.LogDebug?.Invoke("Change in zoom request detected!");
-			zoomer ??= Zoomer.CreateComponent(PlayerManager.PlayerCamera.gameObject, PlayerManager.PlayerCamera.fieldOfView);
+			Zoomer zoomer =
+				PlayerManager.PlayerCamera.gameObject.GetComponent<Zoomer>() ??
+				Zoomer.CreateComponent(PlayerManager.PlayerCamera.gameObject, PlayerManager.PlayerCamera.fieldOfView);
 			zoomer.Zoom(zoomRequested);
 		}
 	}

--- a/VRZoom/Zoomer.cs
+++ b/VRZoom/Zoomer.cs
@@ -41,5 +41,6 @@ class Zoomer : MonoBehaviour
 			yield return null;
 		}
 		Main.LogDebug?.Invoke($"Zoom coroutine [{iteration:D6}]: complete");
+		zoomCoroutine = null;
 	}
 }

--- a/VRZoom/Zoomer.cs
+++ b/VRZoom/Zoomer.cs
@@ -13,6 +13,10 @@ class Zoomer : MonoBehaviour
 		return zoomer;
 	}
 
+	private IEnumerator? zoomCoroutine;
+	private float currentZoomVelocity = 0f;
+	private float hmdFieldOfView;
+
 	public void Zoom(bool zoomIn)
 	{
 		if (zoomCoroutine != null)
@@ -21,14 +25,11 @@ class Zoomer : MonoBehaviour
 			StopCoroutine(zoomCoroutine);
 		}
 		Main.LogDebug?.Invoke($"Starting zoom coroutine with zoom={(zoomIn ? "in" : "out")}");
-		zoomCoroutine = StartCoroutine(DoZoom(zoomIn));
+		zoomCoroutine = StartZoomCoroutine(zoomIn);
+		StartCoroutine(zoomCoroutine);
 	}
 
-	private Coroutine? zoomCoroutine;
-	private float currentZoomVelocity = 0f;
-	private float hmdFieldOfView;
-
-	private IEnumerator DoZoom(bool zoomIn)
+	private IEnumerator StartZoomCoroutine(bool zoomIn)
 	{
 		int iteration = 0;
 		float targetZoomFactor = zoomIn ? hmdFieldOfView / Settings.Instance.ZoomedFOV : 1f;


### PR DESCRIPTION
This PR makes a number of changes in support of fixing a NullReferenceException that previously occurred after loading a second save state. The changes largely involve ensuring instance references don't outlive the instance they reference, achieved by either setting to null on completion or looking up the instance rather than keeping a local copy.

Closes #4.