### PR TITLE
Pass mod id to UnpatchAll

### DIFF
--- a/VRZoom/Main.cs
+++ b/VRZoom/Main.cs
@@ -33,7 +33,7 @@ public static class Main
 		catch (Exception ex)
 		{
 			modEntry.Logger.LogException($"Failed to load {modEntry.Info.DisplayName}:", ex);
-			harmony?.UnpatchAll();
+			harmony?.UnpatchAll(modEntry.Info.Id);
 			return false;
 		}
 


### PR DESCRIPTION
If no id is passed, Harmony will unpatch all patches from all mods.
https://harmony.pardeike.net/articles/basics.html#unpatching

```csharp
// every patch on every method ever patched (including others patches):
var harmony = new Harmony("my.harmony.id");
harmony.UnpatchAll();

// only the patches that one specific Harmony instance did:
harmony.UnpatchAll("my.harmony.id");
```