### PR TITLE
Rely on default behavior for PatchAll

### DIFF
--- a/VRZoom/Main.cs
+++ b/VRZoom/Main.cs
@@ -1,6 +1,5 @@
 ﻿using HarmonyLib;
 using System;
-using System.Reflection;
 using UnityModManagerNet;
 
 namespace VRZoom;
@@ -34,7 +33,7 @@ public static class Main
 		{
 			LogDebug?.Invoke($"Patching assembly…");
 			harmony = new Harmony(modEntry.Info.Id);
-			harmony.PatchAll(Assembly.GetExecutingAssembly());
+			harmony.PatchAll();
 
 			modEntry.OnGUI = Settings.Instance.Draw;
 			modEntry.OnSaveGUI = Settings.Instance.Save;


### PR DESCRIPTION
Based on an ongoing discussion in derail-valley-modding/template-umm#7. Originally, this didn't work, but now it appears to. Not sure what changed, but may or may not merge this. It sounds like getting and passing the executing assembly may still be more reliable even if calling PatchAll without arguments does technically work.

> This method can fail to use the correct assembly when being inlined. It calls StackTrace.GetFrame(1) which can point to the wrong method/assembly. If you are unsure or run into problems, use <code>PatchAll(Assembly.GetExecutingAssembly())</code> instead.
([source](https://github.com/pardeike/Harmony/blob/master/Harmony/Public/Harmony.cs#L72))